### PR TITLE
Implement Supabase backend with CRUD and auth

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@supabase/supabase-js": "^2.51.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.0",
@@ -73,6 +74,103 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.0.tgz",
+      "integrity": "sha512-OMYNbhGa1Cj4stalJq0VoHm5l7Sj/xY0j9CiYEQCikbQmtiDG3c27EIFA4OD+NxuoHTZmjaW8VJlS3SP+yasEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.15.tgz",
+      "integrity": "sha512-HQKRnwAqdVqJW/P9TjKVK+/ETpW4yQ8tyDPPtRMKOH4Uh3vQD74vmj353CYs8+YwVBKubeUOOEpI9CT8mT4obw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.51.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.51.0.tgz",
+      "integrity": "sha512-jG70XoNFcX3z0h/No0t1Aoc3zoHPtMQk5zaM5v3+sCJ/v5Z3qyoHYkGIg1JUycINPsuuAASZ4ZS43YO6H5wMoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.0",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.11.15",
+        "@supabase/storage-js": "2.7.1"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -185,11 +283,16 @@
       "version": "24.0.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
       "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -241,6 +344,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -971,6 +1083,21 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -1796,7 +1923,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1851,6 +1977,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.51.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.0",

--- a/backend/src/supabase/config/supabase.ts
+++ b/backend/src/supabase/config/supabase.ts
@@ -1,0 +1,13 @@
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://occxzvskpsbvawaifggq.supabase.co';
+const supabaseKey = process.env.SUPABASE_KEY;
+
+if (!supabaseKey) {
+  throw new Error('Missing SUPABASE_KEY environment variable');
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default supabase;

--- a/backend/src/supabase/controllers/appointment.Controller.ts
+++ b/backend/src/supabase/controllers/appointment.Controller.ts
@@ -1,0 +1,195 @@
+import supabase from "../config/supabase.js";
+import { Request, Response } from "express";
+import { AppError } from "../../utils/AppError.js";
+
+// Create a new appointment
+export const createAppointment = async (req: Request, res: Response) => {
+    const {
+        citizen_id,
+        institution_id,
+        staff_id,
+        type,
+        status,
+        scheduled_time,
+        duration,
+        location,
+        notes
+    } = req.body;
+
+    try {
+        const { data, error } = await supabase
+            .from('appointments')
+            .insert([{
+                citizen_id,
+                institution_id,
+                staff_id,
+                type,
+                status: status || 'pending', // Default to 'pending' if not provided
+                scheduled_time: new Date(scheduled_time).toISOString(),
+                duration: duration || 30, // Default to 30 minutes
+                location,
+                notes: notes || null
+            }])
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Failed to create appointment', 400);
+        }
+
+        res.status(201).json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get all appointments
+export const getAppointments = async (req: Request, res: Response) => {
+    try {
+        const { data, error } = await supabase
+            .from('appointments')
+            .select(`
+                *,
+                citizen:citizen_id(*),
+                institution:institution_id(*),
+                staff:staff_id(*)
+            `);
+
+        if (error) throw error;
+        res.json(data);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get appointment by ID
+export const getAppointmentById = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('appointments')
+            .select(`
+                *,
+                citizen:citizen_id(*),
+                institution:institution_id(*),
+                staff:staff_id(*)
+            `)
+            .eq('id', id)
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Appointment not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Update appointment
+export const updateAppointment = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const updates = req.body;
+
+    try {
+        // If updating scheduled_time, convert to ISO string
+        if (updates.scheduled_time) {
+            updates.scheduled_time = new Date(updates.scheduled_time).toISOString();
+        }
+
+        const { data, error } = await supabase
+            .from('appointments')
+            .update(updates)
+            .eq('id', id)
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Appointment not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Delete appointment
+export const deleteAppointment = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { error } = await supabase
+            .from('appointments')
+            .delete()
+            .eq('id', id);
+
+        if (error) throw error;
+        res.status(204).send();
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get appointments by citizen ID
+export const getAppointmentsByCitizenId = async (req: Request, res: Response) => {
+    const { citizenId } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('appointments')
+            .select(`
+                *,
+                institution:institution_id(*),
+                staff:staff_id(*)
+            `)
+            .eq('citizen_id', citizenId);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get appointments by staff ID
+export const getAppointmentsByStaffId = async (req: Request, res: Response) => {
+    const { staffId } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('appointments')
+            .select(`
+                *,
+                citizen:citizen_id(*),
+                institution:institution_id(*)
+            `)
+            .eq('staff_id', staffId);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};

--- a/backend/src/supabase/controllers/citizens.Controller.ts
+++ b/backend/src/supabase/controllers/citizens.Controller.ts
@@ -1,0 +1,155 @@
+import bcrypt from "bcryptjs";
+import supabase from "../config/supabase.js";
+import { Request, Response } from "express";
+import { AppError } from "../../utils/AppError.js";
+
+// Créer un citoyen
+export const createCitizen = async (req: Request, res: Response) => {
+    const {
+        first_name,
+        last_name,
+        email,
+        birth_date,
+        phone_number,
+        address,
+        facial_vector,
+        blood_type,
+        allergies,
+        password,
+    } = req.body;
+
+    try {
+        const hashedPassword = await bcrypt.hash(password, 10);
+        const { data, error } = await supabase.from("citizens").insert([
+            {
+                first_name,
+                last_name,
+                email,
+                birth_date,
+                phone_number,
+                address,
+                facial_vector,
+                blood_type,
+                allergies,
+                password: hashedPassword,
+            },
+        ]);
+
+        if (error) throw error;
+        if (!data) {
+            throw new Error("Data is null or undefined");
+        }
+        // Now TypeScript knows data is not null
+        res.status(201).json(data[0]);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+// Récupérer tous les citoyens
+export const getCitizens = async (req: Request, res: Response) => {
+    try {
+        const { data, error } = await supabase.from("citizens").select();
+
+        if (error) throw error;
+        res.json(data);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Lire un citoyen
+export const getCitizenById = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from("citizens")
+            .select(
+                `
+                *,
+                emergency_contacts:emergency_contacts(*)
+            `
+            )
+            .eq("id", id)
+            .single();
+
+        if (error) throw error;
+        res.json(data);
+    } catch (error) {
+        res.status(404).json({ error: "Citizen not found" });
+    }
+};
+
+// Mettre à jour un citoyen
+export const updateCitizen = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const updates = req.body;
+
+    if (updates.password) {
+        updates.password = await bcrypt.hash(updates.password, 10);
+    }
+
+    try {
+        const { data, error } = await supabase
+            .from("citizens")
+            .update(updates)
+            .eq("id", id);
+
+        if (error) throw error;
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+        res.status(error.statusCode).json({ message: error.message });
+      } else {
+        res.status(500).json({ message: 'Internal server error' });
+      }
+    }
+};
+
+// Supprimer un citoyen
+export const deleteCitizen = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { error } = await supabase.from("citizens").delete().eq("id", id);
+
+        if (error) throw error;
+        res.status(204).send();
+    } catch (error) {
+         if (error instanceof AppError) {
+        res.status(error.statusCode).json({ message: error.message });
+      } else {
+        res.status(500).json({ message: 'Internal server error' });
+      }
+    }
+};
+
+// Authentification
+export const login = async (req: Request, res: Response) => {
+    const { email, password } = req.body;
+
+    try {
+        const { data: citizen, error } = await supabase
+            .from("citizens")
+            .select("*")
+            .eq("email", email)
+            .single();
+
+        if (error || !citizen) throw new Error("Invalid credentials");
+
+        const validPassword = await bcrypt.compare(password, citizen.password);
+        if (!validPassword) throw new Error("Invalid credentials");
+
+        res.json({ message: "Login successful", citizenId: citizen.id });
+    } catch (error) {
+         if (error instanceof AppError) {
+        res.status(error.statusCode).json({ message: error.message });
+      } else {
+        res.status(500).json({ message: 'Internal server error' });
+      }
+    }
+};

--- a/backend/src/supabase/controllers/demande.Controller.ts
+++ b/backend/src/supabase/controllers/demande.Controller.ts
@@ -1,0 +1,192 @@
+import supabase from "../config/supabase.js";
+import { Request, Response } from "express";
+import { AppError } from "../../utils/AppError.js";
+
+// Create a new demand
+export const createDemande = async (req: Request, res: Response) => {
+    const {
+        citizen_id,
+        institution_id,
+        service_id,
+        type,
+        title,
+        description,
+        status = 'pending',
+        admin_id = null,
+        admin_name = null,
+        admin_email = null
+    } = req.body;
+
+    try {
+        const { data, error } = await supabase
+            .from('demandes')
+            .insert([{
+                citizen_id,
+                institution_id,
+                service_id,
+                type,
+                title,
+                description,
+                status,
+                admin_id,
+                admin_name,
+                admin_email
+            }])
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Failed to create demand', 400);
+        }
+
+        res.status(201).json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get all demands
+export const getDemandes = async (req: Request, res: Response) => {
+    try {
+        const { data, error } = await supabase
+            .from('demandes')
+            .select(`
+                *,
+                citizen:citizen_id(*),
+                institution:institution_id(*),
+                service:service_id(*)
+            `);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get demand by ID
+export const getDemandeById = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('demandes')
+            .select(`
+                *,
+                citizen:citizen_id(*),
+                institution:institution_id(*),
+                service:service_id(*)
+            `)
+            .eq('id', id)
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Demand not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Update demand
+export const updateDemande = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const updates = req.body;
+
+    try {
+        const { data, error } = await supabase
+            .from('demandes')
+            .update(updates)
+            .eq('id', id)
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Demand not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Delete demand
+export const deleteDemande = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { error } = await supabase
+            .from('demandes')
+            .delete()
+            .eq('id', id);
+
+        if (error) throw error;
+        res.status(204).send();
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get demands by citizen ID
+export const getDemandesByCitizenId = async (req: Request, res: Response) => {
+    const { citizenId } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('demandes')
+            .select(`
+                *,
+                institution:institution_id(*),
+                service:service_id(*)
+            `)
+            .eq('citizen_id', citizenId);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get demands by institution ID
+export const getDemandesByInstitutionId = async (req: Request, res: Response) => {
+    const { institutionId } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('demandes')
+            .select(`
+                *,
+                citizen:citizen_id(*),
+                service:service_id(*)
+            `)
+            .eq('institution_id', institutionId);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};

--- a/backend/src/supabase/controllers/institution.Controller.ts
+++ b/backend/src/supabase/controllers/institution.Controller.ts
@@ -1,0 +1,214 @@
+import supabase from "../config/supabase.js";
+import { Request, Response } from "express";
+import { AppError } from "../../utils/AppError.js";
+
+// Create a new institution
+export const createInstitution = async (req: Request, res: Response) => {
+    const {
+        name,
+        type,
+        address,
+        contact,
+        emergency_access = {
+            enabled: false,
+            facial_recognition: false,
+            emergency_contacts: []
+        },
+        services = []
+    } = req.body;
+
+    try {
+        const { data, error } = await supabase
+            .from('institutions')
+            .insert([{
+                name,
+                type,
+                address,
+                contact: {
+                    phone: contact?.phone || null,
+                    email: contact?.email || null,
+                    website: contact?.website || null
+                },
+                emergency_access,
+                services,
+                statistics: {
+                    total_requests: 0,
+                    average_processing_time: 0,
+                    satisfaction_score: 0,
+                    last_updated: new Date().toISOString()
+                }
+            }])
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Failed to create institution', 400);
+        }
+
+        res.status(201).json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get all institutions
+export const getInstitutions = async (req: Request, res: Response) => {
+    try {
+        const { data, error } = await supabase
+            .from('institutions')
+            .select('*');
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get institution by ID
+export const getInstitutionById = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('institutions')
+            .select(`
+                *,
+                staff:staff(*),
+                appointments:appointments(*),
+                requests:requests(*)
+            `)
+            .eq('id', id)
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Institution not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Update institution
+export const updateInstitution = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const updates = req.body;
+
+    try {
+        // If updating statistics, ensure last_updated is current time
+        if (updates.statistics) {
+            updates.statistics.last_updated = new Date().toISOString();
+        }
+
+        const { data, error } = await supabase
+            .from('institutions')
+            .update(updates)
+            .eq('id', id)
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Institution not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Delete institution
+export const deleteInstitution = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        // First, check if the institution has any associated records
+        const { data: hasDependencies, error: checkError } = await supabase
+            .from('institutions')
+            .select('id, staff, appointments, requests')
+            .eq('id', id)
+            .single();
+
+        if (checkError) throw checkError;
+        
+        if (hasDependencies?.staff?.length > 0 || 
+            hasDependencies?.appointments?.length > 0 || 
+            hasDependencies?.requests?.length > 0) {
+            throw new AppError('Cannot delete institution with associated records', 400);
+        }
+
+        const { error } = await supabase
+            .from('institutions')
+            .delete()
+            .eq('id', id);
+
+        if (error) throw error;
+        res.status(204).send();
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get institutions by type
+export const getInstitutionsByType = async (req: Request, res: Response) => {
+    const { type } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('institutions')
+            .select('*')
+            .eq('type', type);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get institution statistics
+export const getInstitutionStatistics = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('institutions')
+            .select('statistics')
+            .eq('id', id)
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Institution not found', 404);
+        }
+
+        res.json(data.statistics || {});
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};

--- a/backend/src/supabase/controllers/staff.Controller.ts
+++ b/backend/src/supabase/controllers/staff.Controller.ts
@@ -1,0 +1,238 @@
+import supabase from "../config/supabase.js";
+import { Request, Response } from "express";
+import { AppError } from "../../utils/AppError.js";
+
+// Create a new staff member
+export const createStaff = async (req: Request, res: Response) => {
+    const {
+        first_name,
+        last_name,
+        email,
+        phone_number,
+        institution_id,
+        role = 'other',
+        department = '',
+        schedule = {},
+        permissions = {
+            read_citizen_data: false,
+            write_requests: false,
+            manage_appointments: false,
+            emergency_access: false
+        },
+        emergency_access = {
+            enabled: false,
+            facial_recognition: false
+        }
+    } = req.body;
+
+    try {
+        const { data, error } = await supabase
+            .from('staff')
+            .insert([{
+                first_name,
+                last_name,
+                email,
+                phone_number,
+                institution_id,
+                role,
+                department,
+                schedule: {
+                    start: schedule?.start || null,
+                    end: schedule?.end || null,
+                    days: schedule?.days || []
+                },
+                current_appointments: [],
+                availability: {
+                    status: 'off_duty',
+                    next_available: null
+                },
+                permissions,
+                emergency_access,
+                credentials: {
+                    last_login: null,
+                    failed_attempts: 0
+                }
+            }])
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Failed to create staff member', 400);
+        }
+
+        res.status(201).json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get all staff members
+export const getStaff = async (req: Request, res: Response) => {
+    try {
+        const { data, error } = await supabase
+            .from('staff')
+            .select('*');
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Get staff by ID
+export const getStaffById = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('staff')
+            .select(`
+                *,
+                institution:institution_id(*)
+            `)
+            .eq('id', id)
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Staff member not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Update staff member
+export const updateStaff = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const updates = req.body;
+
+    try {
+        // If updating credentials, only update specific fields
+        if (updates.credentials) {
+            updates.credentials.last_updated = new Date().toISOString();
+        }
+
+        const { data, error } = await supabase
+            .from('staff')
+            .update(updates)
+            .eq('id', id)
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Staff member not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Delete staff member
+export const deleteStaff = async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    try {
+        // First, check if the staff member has any appointments
+        const { data: hasAppointments, error: checkError } = await supabase
+            .from('appointments')
+            .select('id')
+            .eq('staff_id', id)
+            .limit(1);
+
+        if (checkError) throw checkError;
+        
+        if (hasAppointments && hasAppointments.length > 0) {
+            throw new AppError('Cannot delete staff member with assigned appointments', 400);
+        }
+
+        const { error } = await supabase
+            .from('staff')
+            .delete()
+            .eq('id', id);
+
+        if (error) throw error;
+        res.status(204).send();
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};
+
+// Get staff by institution
+export const getStaffByInstitution = async (req: Request, res: Response) => {
+    const { institutionId } = req.params;
+
+    try {
+        const { data, error } = await supabase
+            .from('staff')
+            .select('*')
+            .eq('institution_id', institutionId);
+
+        if (error) throw error;
+        res.json(data || []);
+    } catch (error) {
+        res.status(500).json({ message: 'Internal server error' });
+    }
+};
+
+// Update staff availability
+export const updateStaffAvailability = async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const { status, next_available } = req.body;
+
+    try {
+        const updates: any = {
+            availability: {
+                status: status || 'off_duty',
+                updated_at: new Date().toISOString()
+            }
+        };
+
+        if (next_available) {
+            updates.availability.next_available = new Date(next_available).toISOString();
+        }
+
+        const { data, error } = await supabase
+            .from('staff')
+            .update(updates)
+            .eq('id', id)
+            .select()
+            .single();
+
+        if (error) throw error;
+        if (!data) {
+            throw new AppError('Staff member not found', 404);
+        }
+
+        res.json(data);
+    } catch (error) {
+        if (error instanceof AppError) {
+            res.status(error.statusCode).json({ message: error.message });
+        } else {
+            res.status(500).json({ message: 'Internal server error' });
+        }
+    }
+};

--- a/backend/src/supabase/routes/appointment.routes.ts
+++ b/backend/src/supabase/routes/appointment.routes.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { 
+    createAppointment, 
+    deleteAppointment, 
+    getAppointmentById, 
+    getAppointments,
+    getAppointmentsByCitizenId,
+    getAppointmentsByStaffId,
+    updateAppointment 
+} from "../controllers/appointment.Controller.js";
+
+export const routerAppointments = express.Router();
+
+// Create a new appointment
+routerAppointments.post('/appointments', createAppointment);
+
+// Get all appointments
+routerAppointments.get('/appointments', getAppointments);
+
+// Get appointment by ID
+routerAppointments.get('/appointments/:id', getAppointmentById);
+
+// Update appointment
+routerAppointments.put('/appointments/:id', updateAppointment);
+
+// Delete appointment
+routerAppointments.delete('/appointments/:id', deleteAppointment);
+
+// Get appointments by citizen ID
+routerAppointments.get('/citizens/:citizenId/appointments', getAppointmentsByCitizenId);
+
+// Get appointments by staff ID
+routerAppointments.get('/staff/:staffId/appointments', getAppointmentsByStaffId);

--- a/backend/src/supabase/routes/demande.routes.ts
+++ b/backend/src/supabase/routes/demande.routes.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { 
+    createDemande, 
+    deleteDemande, 
+    getDemandeById, 
+    getDemandes,
+    getDemandesByCitizenId,
+    getDemandesByInstitutionId,
+    updateDemande 
+} from "../controllers/demande.Controller.js";
+
+export const routerDemandes = express.Router();
+
+// Create a new demand
+routerDemandes.post('/demandes', createDemande);
+
+// Get all demands
+routerDemandes.get('/demandes', getDemandes);
+
+// Get demand by ID
+routerDemandes.get('/demandes/:id', getDemandeById);
+
+// Update demand
+routerDemandes.put('/demandes/:id', updateDemande);
+
+// Delete demand
+routerDemandes.delete('/demandes/:id', deleteDemande);
+
+// Get demands by citizen ID
+routerDemandes.get('/citizens/:citizenId/demandes', getDemandesByCitizenId);
+
+// Get demands by institution ID
+routerDemandes.get('/institutions/:institutionId/demandes', getDemandesByInstitutionId);

--- a/backend/src/supabase/routes/institution.routes.ts
+++ b/backend/src/supabase/routes/institution.routes.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { 
+    createInstitution, 
+    deleteInstitution, 
+    getInstitutionById, 
+    getInstitutions,
+    getInstitutionsByType,
+    getInstitutionStatistics,
+    updateInstitution 
+} from "../controllers/institution.Controller.js";
+
+export const routerInstitutions = express.Router();
+
+// Create a new institution
+routerInstitutions.post('/institutions', createInstitution);
+
+// Get all institutions
+routerInstitutions.get('/institutions', getInstitutions);
+
+// Get institution by ID
+routerInstitutions.get('/institutions/:id', getInstitutionById);
+
+// Update institution
+routerInstitutions.put('/institutions/:id', updateInstitution);
+
+// Delete institution
+routerInstitutions.delete('/institutions/:id', deleteInstitution);
+
+// Get institutions by type
+routerInstitutions.get('/institutions/type/:type', getInstitutionsByType);
+
+// Get institution statistics
+routerInstitutions.get('/institutions/:id/statistics', getInstitutionStatistics);

--- a/backend/src/supabase/routes/staff.routes.ts
+++ b/backend/src/supabase/routes/staff.routes.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { 
+    createStaff, 
+    deleteStaff, 
+    getStaff, 
+    getStaffById,
+    getStaffByInstitution,
+    updateStaff,
+    updateStaffAvailability 
+} from "../controllers/staff.Controller.js";
+
+export const routerStaff = express.Router();
+
+// Create a new staff member
+routerStaff.post('/staff', createStaff);
+
+// Get all staff members
+routerStaff.get('/staff', getStaff);
+
+// Get staff by ID
+routerStaff.get('/staff/:id', getStaffById);
+
+// Update staff member
+routerStaff.put('/staff/:id', updateStaff);
+
+// Delete staff member
+routerStaff.delete('/staff/:id', deleteStaff);
+
+// Get staff by institution
+routerStaff.get('/institutions/:institutionId/staff', getStaffByInstitution);
+
+// Update staff availability
+routerStaff.patch('/staff/:id/availability', updateStaffAvailability);


### PR DESCRIPTION
## Summary

Integrate Supabase as the primary datastore and implement full CRUD support for staff, institutions, appointments, demands, and citizens, including authentication and environment-based configuration.

New Features:
- Add Supabase client configuration with environment key validation
- Implement Supabase-backed controllers for staff, institution, appointment, demand, and citizen entities
- Expose CRUD endpoints and query routes for all resources via Express routers
- Add citizen authentication flow with password hashing and login endpoint

Build:
- Add @supabase/supabase-js dependency to the backend